### PR TITLE
Improve the dependency to `datamodel-code-generator`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ classifiers = [
 dynamic = ["version", "description"]
 dependencies = [
     "pydantic >=1.6,<2.0",
-    "datamodel-code-generator >=0.12.0",
 ]
 
 [project.urls]
@@ -67,6 +66,7 @@ dev = [
     "pyyaml >=5.3",
     "pdoc3 >=0.9.2",
     "pre-commit >=2.15.0",
+    "datamodel-code-generator >=0.12.0",
 ]
 
 [tool.isort]


### PR DESCRIPTION
## Overview
`datamodel-code-generator` isn't probably required except the development mode.