### PR TITLE
default extra in model config to `allow`

### DIFF
--- a/dbt_artifacts_parser/parsers/catalog/catalog_v1.py
+++ b/dbt_artifacts_parser/parsers/catalog/catalog_v1.py
@@ -12,7 +12,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class CatalogMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/catalog/v1.json'
     dbt_version: Optional[str] = '0.19.0'
@@ -23,7 +23,7 @@ class CatalogMetadata(BaseParserModel):
 
 class TableMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: str
     database: Optional[str] = None
@@ -35,7 +35,7 @@ class TableMetadata(BaseParserModel):
 
 class ColumnMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: str
     comment: Optional[str] = None
@@ -45,7 +45,7 @@ class ColumnMetadata(BaseParserModel):
 
 class StatsItem(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     label: str
@@ -56,7 +56,7 @@ class StatsItem(BaseParserModel):
 
 class CatalogTable(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: TableMetadata
     columns: Dict[str, ColumnMetadata]
@@ -66,7 +66,7 @@ class CatalogTable(BaseParserModel):
 
 class CatalogV1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: CatalogMetadata
     nodes: Dict[str, CatalogTable]

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v1.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v1.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -136,7 +136,7 @@ class ResourceType5(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     namespace: Optional[str] = None
     name: str
@@ -181,7 +181,7 @@ class ResourceType9(Enum):
 
 class ParsedDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -252,7 +252,7 @@ class ResourceType13(Enum):
 
 class ParsedSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -313,7 +313,7 @@ class ResourceType14(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -463,7 +463,7 @@ class ResourceType16(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -473,7 +473,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v1.json'
     dbt_version: Optional[str] = '0.19.0'
@@ -488,7 +488,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -510,7 +510,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     period: Period
@@ -539,14 +539,14 @@ class ResourceType17(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -555,7 +555,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -596,7 +596,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     email: str
     name: Optional[str] = None
@@ -623,7 +623,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -683,7 +683,7 @@ class CompiledDataTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -742,7 +742,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -802,7 +802,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -861,7 +861,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -923,7 +923,7 @@ class CompiledSchemaTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -983,7 +983,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1042,7 +1042,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1096,7 +1096,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1151,7 +1151,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1205,7 +1205,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1259,7 +1259,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1295,7 +1295,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -1304,7 +1304,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1328,7 +1328,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -1353,7 +1353,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     unique_id: str
@@ -1377,7 +1377,7 @@ class ParsedExposure(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1436,7 +1436,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1475,7 +1475,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v10.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v10.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[
         str
@@ -44,7 +44,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -58,7 +58,7 @@ class OnConfigurationChange(Enum):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -67,7 +67,7 @@ class Hook(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -75,7 +75,7 @@ class Docs(BaseParserModel):
 
 class ContractConfig(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
 
@@ -91,7 +91,7 @@ class Type(Enum):
 
 class ColumnLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -102,7 +102,7 @@ class ColumnLevelConstraint(BaseParserModel):
 
 class RefArgs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     package: Optional[str] = None
@@ -111,7 +111,7 @@ class RefArgs(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -119,7 +119,7 @@ class DependsOn(BaseParserModel):
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -127,7 +127,7 @@ class InjectedCTE(BaseParserModel):
 
 class Contract(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     checksum: Optional[str] = None
@@ -176,7 +176,7 @@ class Access(Enum):
 
 class ModelLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -188,7 +188,7 @@ class ModelLevelConstraint(BaseParserModel):
 
 class DeferRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -210,7 +210,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -297,7 +297,7 @@ class SeedConfig(BaseParserModel):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
 
@@ -308,7 +308,7 @@ class ResourceType9(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -324,7 +324,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -358,7 +358,7 @@ class SupportedLanguage(Enum):
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -371,7 +371,7 @@ class ResourceType11(Enum):
 
 class Documentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType11
@@ -436,7 +436,7 @@ class GrainToDate(Enum):
 
 class WhereFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_sql_template: str
 
@@ -459,7 +459,7 @@ class Granularity(Enum):
 
 class MetricTimeWindow(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -467,7 +467,7 @@ class MetricTimeWindow(BaseParserModel):
 
 class FileSlice(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     filename: str
     content: str
@@ -489,7 +489,7 @@ class ResourceType14(Enum):
 
 class Group(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType14
@@ -520,7 +520,7 @@ class ResourceType15(Enum):
 
 class NodeRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     alias: str
     schema_name: str
@@ -530,7 +530,7 @@ class NodeRelation(BaseParserModel):
 
 class Defaults(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     agg_time_dimension: Optional[str] = None
 
@@ -544,7 +544,7 @@ class Type4(Enum):
 
 class Entity(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Type4
@@ -567,7 +567,7 @@ class Agg(Enum):
 
 class MeasureAggregationParameters(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     percentile: Optional[float] = None
     use_discrete_percentile: Optional[bool] = False
@@ -588,7 +588,7 @@ class WindowChoice(Enum):
 
 class NonAdditiveDimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     window_choice: WindowChoice
@@ -610,7 +610,7 @@ class TimeGranularity(Enum):
 
 class DimensionValidityParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     is_start: Optional[bool] = False
     is_end: Optional[bool] = False
@@ -670,7 +670,7 @@ class ColumnInfo(BaseParserModel):
 
 class SingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -741,7 +741,7 @@ class SingularTestNode(BaseParserModel):
 
 class HookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -820,7 +820,7 @@ class HookNode(BaseParserModel):
 
 class ModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -904,7 +904,7 @@ class ModelNode(BaseParserModel):
 
 class RPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -982,7 +982,7 @@ class RPCNode(BaseParserModel):
 
 class SqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1060,7 +1060,7 @@ class SqlNode(BaseParserModel):
 
 class GenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     test_metadata: TestMetadata
     database: Optional[str] = None
@@ -1135,7 +1135,7 @@ class GenericTestNode(BaseParserModel):
 
 class SnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1187,7 +1187,7 @@ class SnapshotNode(BaseParserModel):
 
 class SeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1254,7 +1254,7 @@ class SeedNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1274,7 +1274,7 @@ class ExternalTable(BaseParserModel):
 
 class Macro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType10
@@ -1299,7 +1299,7 @@ class Macro(BaseParserModel):
 
 class Exposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType12
@@ -1331,7 +1331,7 @@ class Exposure(BaseParserModel):
 
 class MetricInputMeasure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[WhereFilter] = None
@@ -1340,7 +1340,7 @@ class MetricInputMeasure(BaseParserModel):
 
 class MetricInput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[WhereFilter] = None
@@ -1351,7 +1351,7 @@ class MetricInput(BaseParserModel):
 
 class SourceFileMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     repo_file_path: str
     file_slice: FileSlice
@@ -1359,7 +1359,7 @@ class SourceFileMetadata(BaseParserModel):
 
 class Measure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     agg: Agg
@@ -1373,7 +1373,7 @@ class Measure(BaseParserModel):
 
 class DimensionTypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     time_granularity: TimeGranularity
     validity_params: Optional[DimensionValidityParams] = None
@@ -1381,7 +1381,7 @@ class DimensionTypeParams(BaseParserModel):
 
 class AnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1459,7 +1459,7 @@ class AnalysisNode(BaseParserModel):
 
 class SourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1498,7 +1498,7 @@ class SourceDefinition(BaseParserModel):
 
 class MetricTypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     measure: Optional[MetricInputMeasure] = None
     input_measures: Optional[List[MetricInputMeasure]] = []
@@ -1512,7 +1512,7 @@ class MetricTypeParams(BaseParserModel):
 
 class Dimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Type5
@@ -1525,7 +1525,7 @@ class Dimension(BaseParserModel):
 
 class Metric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType13
@@ -1560,7 +1560,7 @@ class Metric(BaseParserModel):
 
 class SemanticModel(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType15
@@ -1590,7 +1590,7 @@ class SemanticModel(BaseParserModel):
 
 class ManifestV10(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v11.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v11.py
@@ -14,7 +14,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = None
     dbt_version: Optional[str] = '1.8.0a1'
@@ -39,7 +39,7 @@ class ManifestMetadata(BaseParserModel):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -47,7 +47,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -56,7 +56,7 @@ class Hook(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -64,7 +64,7 @@ class Docs(BaseParserModel):
 
 class ContractConfig(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -116,7 +116,7 @@ class Type(Enum):
 
 class ColumnLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -141,7 +141,7 @@ class ColumnInfo(BaseParserModel):
 
 class RefArgs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     package: Optional[str] = None
@@ -150,7 +150,7 @@ class RefArgs(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = None
     nodes: Optional[List[str]] = None
@@ -158,7 +158,7 @@ class DependsOn(BaseParserModel):
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -166,7 +166,7 @@ class InjectedCTE(BaseParserModel):
 
 class Contract(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -175,7 +175,7 @@ class Contract(BaseParserModel):
 
 class AnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -245,7 +245,7 @@ class TestConfig(BaseParserModel):
 
 class SingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -290,7 +290,7 @@ class SingularTestNode(BaseParserModel):
 
 class HookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -372,7 +372,7 @@ class ModelConfig(BaseParserModel):
 
 class ModelLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -384,7 +384,7 @@ class ModelLevelConstraint(BaseParserModel):
 
 class DeferRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -394,7 +394,7 @@ class DeferRelation(BaseParserModel):
 
 class ModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -445,7 +445,7 @@ class ModelNode(BaseParserModel):
 
 class RPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -490,7 +490,7 @@ class RPCNode(BaseParserModel):
 
 class SqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -535,7 +535,7 @@ class SqlNode(BaseParserModel):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = None
@@ -544,7 +544,7 @@ class TestMetadata(BaseParserModel):
 
 class GenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     test_metadata: TestMetadata
     database: Optional[str] = None
@@ -627,7 +627,7 @@ class SnapshotConfig(BaseParserModel):
 
 class SnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -704,14 +704,14 @@ class SeedConfig(BaseParserModel):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = None
 
 
 class SeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -747,7 +747,7 @@ class SeedNode(BaseParserModel):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -763,7 +763,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -771,7 +771,7 @@ class Time(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -811,7 +811,7 @@ class SourceConfig(BaseParserModel):
 
 class SourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -845,7 +845,7 @@ class SourceDefinition(BaseParserModel):
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -859,7 +859,7 @@ class SupportedLanguage(Enum):
 
 class Macro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['macro']
@@ -880,7 +880,7 @@ class Macro(BaseParserModel):
 
 class Documentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['doc']
@@ -924,7 +924,7 @@ class Maturity(Enum):
 
 class Exposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['exposure']
@@ -952,21 +952,21 @@ class Exposure(BaseParserModel):
 
 class WhereFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_sql_template: str
 
 
 class WhereFilterIntersection(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class MetricInputMeasure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[WhereFilterIntersection] = None
@@ -985,7 +985,7 @@ class Granularity(Enum):
 
 class MetricTimeWindow(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -1001,7 +1001,7 @@ class OffsetToGrain(Enum):
 
 class MetricInput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[WhereFilterIntersection] = None
@@ -1020,7 +1020,7 @@ class GrainToDate(Enum):
 
 class MetricTypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     measure: Optional[MetricInputMeasure] = None
     input_measures: Optional[List[MetricInputMeasure]] = None
@@ -1034,7 +1034,7 @@ class MetricTypeParams(BaseParserModel):
 
 class FileSlice(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     filename: str
     content: str
@@ -1044,7 +1044,7 @@ class FileSlice(BaseParserModel):
 
 class SourceFileMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     repo_file_path: str
     file_slice: FileSlice
@@ -1068,7 +1068,7 @@ class Type3(Enum):
 
 class Metric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['metric']
@@ -1097,7 +1097,7 @@ class Metric(BaseParserModel):
 
 class Group(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['group']
@@ -1110,7 +1110,7 @@ class Group(BaseParserModel):
 
 class QueryParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metrics: List[str]
     group_by: List[str]
@@ -1124,7 +1124,7 @@ class ExportAs(Enum):
 
 class ExportConfig(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     export_as: ExportAs
     schema_name: Optional[str] = None
@@ -1133,7 +1133,7 @@ class ExportConfig(BaseParserModel):
 
 class Export(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     config: ExportConfig
@@ -1170,7 +1170,7 @@ class ResourceType(Enum):
 
 class SavedQuery(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType
@@ -1194,7 +1194,7 @@ class SavedQuery(BaseParserModel):
 
 class NodeRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     alias: str
     schema_name: str
@@ -1204,7 +1204,7 @@ class NodeRelation(BaseParserModel):
 
 class Defaults(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     agg_time_dimension: Optional[str] = None
 
@@ -1218,7 +1218,7 @@ class Type4(Enum):
 
 class Entity(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Type4
@@ -1230,7 +1230,7 @@ class Entity(BaseParserModel):
 
 class MeasureAggregationParameters(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     percentile: Optional[float] = None
     use_discrete_percentile: Optional[bool] = False
@@ -1251,7 +1251,7 @@ class WindowChoice(Enum):
 
 class NonAdditiveDimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     window_choice: WindowChoice
@@ -1272,7 +1272,7 @@ class Agg(Enum):
 
 class Measure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     agg: Agg
@@ -1287,7 +1287,7 @@ class Measure(BaseParserModel):
 
 class DimensionValidityParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     is_start: Optional[bool] = False
     is_end: Optional[bool] = False
@@ -1303,7 +1303,7 @@ class TimeGranularity(Enum):
 
 class DimensionTypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     time_granularity: TimeGranularity
     validity_params: Optional[DimensionValidityParams] = None
@@ -1316,7 +1316,7 @@ class Type5(Enum):
 
 class Dimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Type5
@@ -1340,7 +1340,7 @@ class SemanticModelConfig(BaseParserModel):
 
 class SemanticModel(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType
@@ -1369,7 +1369,7 @@ class SemanticModel(BaseParserModel):
 
 class ManifestV11(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
@@ -14,7 +14,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class Metadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = None
     dbt_version: Optional[str] = '1.8.0b3'
@@ -39,7 +39,7 @@ class Metadata(BaseParserModel):
 
 class Checksum(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -47,7 +47,7 @@ class Checksum(BaseParserModel):
 
 class PostHookItem(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -56,7 +56,7 @@ class PostHookItem(BaseParserModel):
 
 class PreHookItem(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -71,7 +71,7 @@ class OnConfigurationChange(Enum):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -79,7 +79,7 @@ class Docs(BaseParserModel):
 
 class Contract(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -127,7 +127,7 @@ class Type(Enum):
 
 class Constraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -152,7 +152,7 @@ class Columns(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = None
 
@@ -209,7 +209,7 @@ class Config1(BaseParserModel):
 
 class DeferRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -226,7 +226,7 @@ class DeferRelation(BaseParserModel):
 
 class Nodes(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -289,7 +289,7 @@ class Config2(BaseParserModel):
 
 class Constraint1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -314,7 +314,7 @@ class Columns1(BaseParserModel):
 
 class Ref(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     package: Optional[str] = None
@@ -323,7 +323,7 @@ class Ref(BaseParserModel):
 
 class DependsOn1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = None
     nodes: Optional[List[str]] = None
@@ -331,7 +331,7 @@ class DependsOn1(BaseParserModel):
 
 class ExtraCte(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -339,7 +339,7 @@ class ExtraCte(BaseParserModel):
 
 class Contract3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -348,7 +348,7 @@ class Contract3(BaseParserModel):
 
 class Nodes1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -416,7 +416,7 @@ class Config3(BaseParserModel):
 
 class Constraint2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -441,7 +441,7 @@ class Columns2(BaseParserModel):
 
 class Nodes2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -484,7 +484,7 @@ class Nodes2(BaseParserModel):
 
 class Contract5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -521,7 +521,7 @@ class Config4(BaseParserModel):
 
 class Constraint3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -546,7 +546,7 @@ class Columns3(BaseParserModel):
 
 class Contract6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -555,7 +555,7 @@ class Contract6(BaseParserModel):
 
 class Nodes3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -599,7 +599,7 @@ class Nodes3(BaseParserModel):
 
 class Contract7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -643,7 +643,7 @@ class Config5(BaseParserModel):
 
 class Constraint4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -668,7 +668,7 @@ class Columns4(BaseParserModel):
 
 class Contract8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -677,7 +677,7 @@ class Contract8(BaseParserModel):
 
 class Constraint5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -689,7 +689,7 @@ class Constraint5(BaseParserModel):
 
 class Contract9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -726,7 +726,7 @@ class Config6(BaseParserModel):
 
 class DeferRelation1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -743,7 +743,7 @@ class DeferRelation1(BaseParserModel):
 
 class Nodes4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -822,7 +822,7 @@ class Config7(BaseParserModel):
 
 class Constraint6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -847,7 +847,7 @@ class Columns5(BaseParserModel):
 
 class Contract11(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -856,7 +856,7 @@ class Contract11(BaseParserModel):
 
 class Nodes5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -924,7 +924,7 @@ class Config8(BaseParserModel):
 
 class Constraint7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -949,7 +949,7 @@ class Columns6(BaseParserModel):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: Optional[str] = 'test'
     kwargs: Optional[Dict[str, Any]] = None
@@ -958,7 +958,7 @@ class TestMetadata(BaseParserModel):
 
 class Nodes6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1005,7 +1005,7 @@ class Nodes6(BaseParserModel):
 
 class Contract13(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -1047,7 +1047,7 @@ class Config9(BaseParserModel):
 
 class Constraint8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -1072,7 +1072,7 @@ class Columns7(BaseParserModel):
 
 class Contract14(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -1081,7 +1081,7 @@ class Contract14(BaseParserModel):
 
 class Contract15(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -1118,7 +1118,7 @@ class Config10(BaseParserModel):
 
 class DeferRelation2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1135,7 +1135,7 @@ class DeferRelation2(BaseParserModel):
 
 class Nodes7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1179,7 +1179,7 @@ class Nodes7(BaseParserModel):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -1195,7 +1195,7 @@ class Period(Enum):
 
 class WarnAfter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -1203,7 +1203,7 @@ class WarnAfter(BaseParserModel):
 
 class ErrorAfter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -1211,7 +1211,7 @@ class ErrorAfter(BaseParserModel):
 
 class Freshness(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[WarnAfter] = None
     error_after: Optional[ErrorAfter] = None
@@ -1243,7 +1243,7 @@ class External(BaseParserModel):
 
 class Constraint9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -1276,7 +1276,7 @@ class Config11(BaseParserModel):
 
 class Sources(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1309,14 +1309,14 @@ class Sources(BaseParserModel):
 
 class DependsOn8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = None
 
 
 class Argument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -1330,7 +1330,7 @@ class SupportedLanguage(Enum):
 
 class Macros(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['macro']
@@ -1351,7 +1351,7 @@ class Macros(BaseParserModel):
 
 class Docs18(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['doc']
@@ -1387,7 +1387,7 @@ class Maturity(Enum):
 
 class DependsOn9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = None
     nodes: Optional[List[str]] = None
@@ -1395,7 +1395,7 @@ class DependsOn9(BaseParserModel):
 
 class Exposures(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['exposure']
@@ -1431,21 +1431,21 @@ class Type11(Enum):
 
 class WhereFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_sql_template: str
 
 
 class Filter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class Measure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter] = None
@@ -1456,14 +1456,14 @@ class Measure(BaseParserModel):
 
 class Filter1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class InputMeasure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter1] = None
@@ -1474,7 +1474,7 @@ class InputMeasure(BaseParserModel):
 
 class Filter2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
@@ -1489,7 +1489,7 @@ class Granularity(Enum):
 
 class OffsetWindow(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -1505,7 +1505,7 @@ class OffsetToGrain(Enum):
 
 class Numerator(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter2] = None
@@ -1516,14 +1516,14 @@ class Numerator(BaseParserModel):
 
 class Filter3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class OffsetWindow1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -1531,7 +1531,7 @@ class OffsetWindow1(BaseParserModel):
 
 class Denominator(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter3] = None
@@ -1542,7 +1542,7 @@ class Denominator(BaseParserModel):
 
 class Window(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -1558,14 +1558,14 @@ class GrainToDate(Enum):
 
 class Filter4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class OffsetWindow2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -1573,7 +1573,7 @@ class OffsetWindow2(BaseParserModel):
 
 class Metric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter4] = None
@@ -1584,14 +1584,14 @@ class Metric(BaseParserModel):
 
 class Filter5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class BaseMeasure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter5] = None
@@ -1602,14 +1602,14 @@ class BaseMeasure(BaseParserModel):
 
 class Filter6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class ConversionMeasure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter6] = None
@@ -1625,7 +1625,7 @@ class Calculation(Enum):
 
 class Window1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -1633,7 +1633,7 @@ class Window1(BaseParserModel):
 
 class ConstantProperty(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     base_property: str
     conversion_property: str
@@ -1641,7 +1641,7 @@ class ConstantProperty(BaseParserModel):
 
 class ConversionTypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     base_measure: BaseMeasure = Field(..., title='MetricInputMeasure')
     conversion_measure: ConversionMeasure = Field(..., title='MetricInputMeasure')
@@ -1653,7 +1653,7 @@ class ConversionTypeParams(BaseParserModel):
 
 class TypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     measure: Optional[Measure] = None
     input_measures: Optional[List[InputMeasure]] = None
@@ -1668,14 +1668,14 @@ class TypeParams(BaseParserModel):
 
 class Filter7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class FileSlice(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     filename: str
     content: str
@@ -1685,7 +1685,7 @@ class FileSlice(BaseParserModel):
 
 class Metadata1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -1703,7 +1703,7 @@ class Config13(BaseParserModel):
 
 class Metrics(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['metric']
@@ -1732,7 +1732,7 @@ class Metrics(BaseParserModel):
 
 class Groups(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['group']
@@ -1745,7 +1745,7 @@ class Groups(BaseParserModel):
 
 class Docs19(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -1793,7 +1793,7 @@ class Type12(Enum):
 
 class Constraint10(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type12
     name: Optional[str] = None
@@ -1818,7 +1818,7 @@ class Columns9(BaseParserModel):
 
 class DependsOn11(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = None
 
@@ -1854,7 +1854,7 @@ class Config15(BaseParserModel):
 
 class DeferRelation3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1871,7 +1871,7 @@ class DeferRelation3(BaseParserModel):
 
 class Disabled(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1934,7 +1934,7 @@ class Config16(BaseParserModel):
 
 class Constraint11(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type12
     name: Optional[str] = None
@@ -1959,7 +1959,7 @@ class Columns10(BaseParserModel):
 
 class DependsOn12(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = None
     nodes: Optional[List[str]] = None
@@ -1967,7 +1967,7 @@ class DependsOn12(BaseParserModel):
 
 class Contract19(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -1976,7 +1976,7 @@ class Contract19(BaseParserModel):
 
 class Disabled1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2044,7 +2044,7 @@ class Config17(BaseParserModel):
 
 class Constraint12(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type12
     name: Optional[str] = None
@@ -2069,7 +2069,7 @@ class Columns11(BaseParserModel):
 
 class Disabled2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2112,7 +2112,7 @@ class Disabled2(BaseParserModel):
 
 class Contract21(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2149,7 +2149,7 @@ class Config18(BaseParserModel):
 
 class Constraint13(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type12
     name: Optional[str] = None
@@ -2174,7 +2174,7 @@ class Columns12(BaseParserModel):
 
 class Contract22(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2183,7 +2183,7 @@ class Contract22(BaseParserModel):
 
 class Disabled3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2227,7 +2227,7 @@ class Disabled3(BaseParserModel):
 
 class Contract23(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2265,7 +2265,7 @@ class Config19(BaseParserModel):
 
 class Constraint14(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type12
     name: Optional[str] = None
@@ -2290,7 +2290,7 @@ class Columns13(BaseParserModel):
 
 class Contract24(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2299,7 +2299,7 @@ class Contract24(BaseParserModel):
 
 class Constraint15(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type12
     name: Optional[str] = None
@@ -2311,7 +2311,7 @@ class Constraint15(BaseParserModel):
 
 class Contract25(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2348,7 +2348,7 @@ class Config20(BaseParserModel):
 
 class DeferRelation4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2365,7 +2365,7 @@ class DeferRelation4(BaseParserModel):
 
 class Disabled4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2444,7 +2444,7 @@ class Config21(BaseParserModel):
 
 class Constraint16(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type12
     name: Optional[str] = None
@@ -2469,7 +2469,7 @@ class Columns14(BaseParserModel):
 
 class Contract27(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2478,7 +2478,7 @@ class Contract27(BaseParserModel):
 
 class Disabled5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2546,7 +2546,7 @@ class Config22(BaseParserModel):
 
 class Constraint17(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type12
     name: Optional[str] = None
@@ -2571,7 +2571,7 @@ class Columns15(BaseParserModel):
 
 class Disabled6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2618,7 +2618,7 @@ class Disabled6(BaseParserModel):
 
 class Contract29(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2660,7 +2660,7 @@ class Config23(BaseParserModel):
 
 class Constraint18(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type12
     name: Optional[str] = None
@@ -2685,7 +2685,7 @@ class Columns16(BaseParserModel):
 
 class Contract30(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2694,7 +2694,7 @@ class Contract30(BaseParserModel):
 
 class Contract31(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2731,7 +2731,7 @@ class Config24(BaseParserModel):
 
 class DeferRelation5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2748,7 +2748,7 @@ class DeferRelation5(BaseParserModel):
 
 class Disabled7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2792,7 +2792,7 @@ class Disabled7(BaseParserModel):
 
 class WarnAfter1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -2800,7 +2800,7 @@ class WarnAfter1(BaseParserModel):
 
 class ErrorAfter1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -2808,7 +2808,7 @@ class ErrorAfter1(BaseParserModel):
 
 class Freshness1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[WarnAfter1] = None
     error_after: Optional[ErrorAfter1] = None
@@ -2829,7 +2829,7 @@ class External1(BaseParserModel):
 
 class Constraint19(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type12
     name: Optional[str] = None
@@ -2862,7 +2862,7 @@ class Config25(BaseParserModel):
 
 class Disabled8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2903,7 +2903,7 @@ class Type22(Enum):
 
 class Disabled9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['exposure']
@@ -2939,14 +2939,14 @@ class Type23(Enum):
 
 class Filter8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class Measure1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter8] = None
@@ -2957,14 +2957,14 @@ class Measure1(BaseParserModel):
 
 class Filter9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class InputMeasure1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter9] = None
@@ -2975,14 +2975,14 @@ class InputMeasure1(BaseParserModel):
 
 class Filter10(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class OffsetWindow3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -2990,7 +2990,7 @@ class OffsetWindow3(BaseParserModel):
 
 class Numerator1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter10] = None
@@ -3001,14 +3001,14 @@ class Numerator1(BaseParserModel):
 
 class Filter11(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class OffsetWindow4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -3016,7 +3016,7 @@ class OffsetWindow4(BaseParserModel):
 
 class Denominator1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter11] = None
@@ -3027,7 +3027,7 @@ class Denominator1(BaseParserModel):
 
 class Window2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -3035,14 +3035,14 @@ class Window2(BaseParserModel):
 
 class Filter12(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class OffsetWindow5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -3050,7 +3050,7 @@ class OffsetWindow5(BaseParserModel):
 
 class Metric1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter12] = None
@@ -3061,14 +3061,14 @@ class Metric1(BaseParserModel):
 
 class Filter13(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class BaseMeasure1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter13] = None
@@ -3079,14 +3079,14 @@ class BaseMeasure1(BaseParserModel):
 
 class Filter14(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class ConversionMeasure1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     filter: Optional[Filter14] = None
@@ -3097,7 +3097,7 @@ class ConversionMeasure1(BaseParserModel):
 
 class Window3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     granularity: Granularity
@@ -3105,7 +3105,7 @@ class Window3(BaseParserModel):
 
 class ConversionTypeParams1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     base_measure: BaseMeasure1 = Field(..., title='MetricInputMeasure')
     conversion_measure: ConversionMeasure1 = Field(..., title='MetricInputMeasure')
@@ -3117,7 +3117,7 @@ class ConversionTypeParams1(BaseParserModel):
 
 class TypeParams1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     measure: Optional[Measure1] = None
     input_measures: Optional[List[InputMeasure1]] = None
@@ -3132,14 +3132,14 @@ class TypeParams1(BaseParserModel):
 
 class Filter15(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class Metadata2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3157,7 +3157,7 @@ class Config27(BaseParserModel):
 
 class Disabled10(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: Literal['metric']
@@ -3186,14 +3186,14 @@ class Disabled10(BaseParserModel):
 
 class Where(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class QueryParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metrics: List[str]
     group_by: List[str]
@@ -3207,7 +3207,7 @@ class ExportAs(Enum):
 
 class Config28(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     export_as: ExportAs
     schema_name: Optional[str] = None
@@ -3217,7 +3217,7 @@ class Config28(BaseParserModel):
 
 class Export(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     config: Config28 = Field(..., title='ExportConfig')
@@ -3225,7 +3225,7 @@ class Export(BaseParserModel):
 
 class Metadata3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3233,7 +3233,7 @@ class Metadata3(BaseParserModel):
 
 class Cache(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enabled: Optional[bool] = False
 
@@ -3253,7 +3253,7 @@ class Config29(BaseParserModel):
 
 class Disabled11(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType
@@ -3277,7 +3277,7 @@ class Disabled11(BaseParserModel):
 
 class NodeRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     alias: str
     schema_name: str
@@ -3287,7 +3287,7 @@ class NodeRelation(BaseParserModel):
 
 class Defaults(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     agg_time_dimension: Optional[str] = None
 
@@ -3301,7 +3301,7 @@ class Type24(Enum):
 
 class Entity(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Type24
@@ -3325,7 +3325,7 @@ class Agg(Enum):
 
 class AggParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     percentile: Optional[float] = None
     use_discrete_percentile: Optional[bool] = False
@@ -3346,7 +3346,7 @@ class WindowChoice(Enum):
 
 class NonAdditiveDimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     window_choice: WindowChoice
@@ -3355,7 +3355,7 @@ class NonAdditiveDimension(BaseParserModel):
 
 class Measure2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     agg: Agg
@@ -3383,7 +3383,7 @@ class TimeGranularity(Enum):
 
 class ValidityParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     is_start: Optional[bool] = False
     is_end: Optional[bool] = False
@@ -3391,7 +3391,7 @@ class ValidityParams(BaseParserModel):
 
 class TypeParams2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     time_granularity: TimeGranularity
     validity_params: Optional[ValidityParams] = None
@@ -3399,7 +3399,7 @@ class TypeParams2(BaseParserModel):
 
 class Metadata4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3407,7 +3407,7 @@ class Metadata4(BaseParserModel):
 
 class Dimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Type25
@@ -3421,7 +3421,7 @@ class Dimension(BaseParserModel):
 
 class Metadata5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3439,7 +3439,7 @@ class Config30(BaseParserModel):
 
 class Disabled12(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType
@@ -3474,7 +3474,7 @@ class Format(Enum):
 
 class GivenItem(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     input: str
     rows: Optional[Union[str, List[Dict[str, Any]]]] = None
@@ -3484,7 +3484,7 @@ class GivenItem(BaseParserModel):
 
 class Expect(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     rows: Optional[Union[str, List[Dict[str, Any]]]] = None
     format: Optional[Format] = 'dict'
@@ -3493,7 +3493,7 @@ class Expect(BaseParserModel):
 
 class Overrides(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[Dict[str, Any]] = None
     vars: Optional[Dict[str, Any]] = None
@@ -3511,7 +3511,7 @@ class Config31(BaseParserModel):
 
 class Versions(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     include: Optional[List[Union[str, float]]] = None
     exclude: Optional[List[Union[str, float]]] = None
@@ -3519,7 +3519,7 @@ class Versions(BaseParserModel):
 
 class Disabled13(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     model: str
     given: List[GivenItem]
@@ -3544,14 +3544,14 @@ class Disabled13(BaseParserModel):
 
 class Where1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     where_filters: List[WhereFilter]
 
 
 class QueryParams1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metrics: List[str]
     group_by: List[str]
@@ -3560,7 +3560,7 @@ class QueryParams1(BaseParserModel):
 
 class Config32(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     export_as: ExportAs
     schema_name: Optional[str] = None
@@ -3570,7 +3570,7 @@ class Config32(BaseParserModel):
 
 class Export1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     config: Config32 = Field(..., title='ExportConfig')
@@ -3578,7 +3578,7 @@ class Export1(BaseParserModel):
 
 class Metadata6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3599,7 +3599,7 @@ class Config33(BaseParserModel):
 
 class SavedQueries(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType
@@ -3630,7 +3630,7 @@ class Type26(Enum):
 
 class Entity1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Type26
@@ -3642,7 +3642,7 @@ class Entity1(BaseParserModel):
 
 class NonAdditiveDimension1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     window_choice: WindowChoice
@@ -3651,7 +3651,7 @@ class NonAdditiveDimension1(BaseParserModel):
 
 class Measure3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     agg: Agg
@@ -3671,7 +3671,7 @@ class Type27(Enum):
 
 class TypeParams3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     time_granularity: TimeGranularity
     validity_params: Optional[ValidityParams] = None
@@ -3679,7 +3679,7 @@ class TypeParams3(BaseParserModel):
 
 class Metadata7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3687,7 +3687,7 @@ class Metadata7(BaseParserModel):
 
 class Dimension1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Type27
@@ -3701,7 +3701,7 @@ class Dimension1(BaseParserModel):
 
 class Metadata8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3719,7 +3719,7 @@ class Config34(BaseParserModel):
 
 class SemanticModels(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType
@@ -3748,7 +3748,7 @@ class SemanticModels(BaseParserModel):
 
 class GivenItem1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     input: str
     rows: Optional[Union[str, List[Dict[str, Any]]]] = None
@@ -3758,7 +3758,7 @@ class GivenItem1(BaseParserModel):
 
 class Expect1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     rows: Optional[Union[str, List[Dict[str, Any]]]] = None
     format: Optional[Format] = 'dict'
@@ -3776,7 +3776,7 @@ class Config35(BaseParserModel):
 
 class UnitTests(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     model: str
     given: List[GivenItem1]
@@ -3801,7 +3801,7 @@ class UnitTests(BaseParserModel):
 
 class ManifestV12(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: Metadata = Field(
         ..., description='Metadata about the manifest', title='ManifestMetadata'

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v2.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v2.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -142,7 +142,7 @@ class ResourceType5(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -187,7 +187,7 @@ class ResourceType9(Enum):
 
 class ParsedDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -266,7 +266,7 @@ class ResourceType13(Enum):
 
 class ParsedSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -335,7 +335,7 @@ class ResourceType14(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -425,7 +425,7 @@ class ResourceType16(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -435,7 +435,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v1.json'
     dbt_version: Optional[str] = '0.20.0rc1'
@@ -450,7 +450,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -472,7 +472,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     period: Period
@@ -501,14 +501,14 @@ class ResourceType17(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -517,7 +517,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -558,7 +558,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     email: str
     name: Optional[str] = None
@@ -585,7 +585,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -653,7 +653,7 @@ class CompiledDataTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -714,7 +714,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -776,7 +776,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -837,7 +837,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -907,7 +907,7 @@ class CompiledSchemaTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -969,7 +969,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1030,7 +1030,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1086,7 +1086,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1143,7 +1143,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1199,7 +1199,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1255,7 +1255,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1293,7 +1293,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -1302,7 +1302,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1326,7 +1326,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -1352,7 +1352,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     unique_id: str
@@ -1379,7 +1379,7 @@ class ParsedExposure(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1440,7 +1440,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1480,7 +1480,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v3.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v3.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -136,7 +136,7 @@ class ResourceType5(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -182,7 +182,7 @@ class ResourceType9(Enum):
 
 class ParsedDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -256,7 +256,7 @@ class ResourceType13(Enum):
 
 class ParsedSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -320,7 +320,7 @@ class ResourceType14(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -413,7 +413,7 @@ class ResourceType16(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -423,7 +423,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v2.json'
     dbt_version: Optional[str] = '0.21.0rc1'
@@ -438,7 +438,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -460,7 +460,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     period: Period
@@ -468,7 +468,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -498,14 +498,14 @@ class ResourceType17(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -514,7 +514,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -555,7 +555,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     email: str
     name: Optional[str] = None
@@ -583,7 +583,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -646,7 +646,7 @@ class CompiledDataTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -709,7 +709,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -773,7 +773,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -836,7 +836,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -901,7 +901,7 @@ class CompiledSchemaTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -965,7 +965,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1028,7 +1028,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1086,7 +1086,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1145,7 +1145,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1203,7 +1203,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1261,7 +1261,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1300,7 +1300,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -1309,7 +1309,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1336,7 +1336,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -1362,7 +1362,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     unique_id: str
@@ -1389,7 +1389,7 @@ class ParsedExposure(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1452,7 +1452,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1492,7 +1492,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v4.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v4.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -140,7 +140,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -186,7 +186,7 @@ class ResourceType10(Enum):
 
 class ParsedSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -264,7 +264,7 @@ class ResourceType15(Enum):
 
 class ParsedGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -329,7 +329,7 @@ class ResourceType16(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -422,7 +422,7 @@ class ResourceType18(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -432,7 +432,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.0.0rc2'
@@ -447,7 +447,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -469,7 +469,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -477,7 +477,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -507,14 +507,14 @@ class ResourceType19(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -523,7 +523,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -566,7 +566,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     email: str
     name: Optional[str] = None
@@ -574,7 +574,7 @@ class ExposureOwner(BaseParserModel):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     field: str
     operator: str
@@ -603,7 +603,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -666,7 +666,7 @@ class CompiledSingularTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -729,7 +729,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -793,7 +793,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -856,7 +856,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -919,7 +919,7 @@ class CompiledSqlNode(BaseParserModel):
 
 class CompiledGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -985,7 +985,7 @@ class CompiledGenericTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1049,7 +1049,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1112,7 +1112,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1170,7 +1170,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1229,7 +1229,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1287,7 +1287,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1345,7 +1345,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1403,7 +1403,7 @@ class ParsedSqlNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1442,7 +1442,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1451,7 +1451,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1478,7 +1478,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -1504,7 +1504,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     unique_id: str
@@ -1531,7 +1531,7 @@ class ParsedExposure(BaseParserModel):
 
 class ParsedMetric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     unique_id: str
@@ -1562,7 +1562,7 @@ class ParsedMetric(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1625,7 +1625,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1665,7 +1665,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v5.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v5.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -140,7 +140,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -187,7 +187,7 @@ class ResourceType10(Enum):
 
 class ParsedSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -265,7 +265,7 @@ class ResourceType15(Enum):
 
 class ParsedGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -330,7 +330,7 @@ class ResourceType16(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -424,7 +424,7 @@ class ResourceType18(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -434,7 +434,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.1.0b1'
@@ -449,7 +449,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -471,7 +471,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -479,7 +479,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -509,14 +509,14 @@ class ResourceType19(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -525,7 +525,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -568,7 +568,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     email: str
     name: Optional[str] = None
@@ -576,7 +576,7 @@ class ExposureOwner(BaseParserModel):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     field: str
     operator: str
@@ -606,7 +606,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -669,7 +669,7 @@ class CompiledSingularTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -733,7 +733,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -798,7 +798,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -862,7 +862,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -926,7 +926,7 @@ class CompiledSqlNode(BaseParserModel):
 
 class CompiledGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -992,7 +992,7 @@ class CompiledGenericTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1057,7 +1057,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1121,7 +1121,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1180,7 +1180,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1240,7 +1240,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1299,7 +1299,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1358,7 +1358,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1417,7 +1417,7 @@ class ParsedSqlNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1456,7 +1456,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1465,7 +1465,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1492,7 +1492,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -1518,7 +1518,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     unique_id: str
@@ -1545,7 +1545,7 @@ class ParsedExposure(BaseParserModel):
 
 class ParsedMetric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     unique_id: str
@@ -1576,7 +1576,7 @@ class ParsedMetric(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1640,7 +1640,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1680,7 +1680,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v6.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v6.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -140,7 +140,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -188,7 +188,7 @@ class ResourceType10(Enum):
 
 class ParsedSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -267,7 +267,7 @@ class ResourceType15(Enum):
 
 class ParsedGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -333,7 +333,7 @@ class ResourceType16(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -430,7 +430,7 @@ class ResourceType18(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -440,7 +440,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.2.0'
@@ -455,7 +455,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -477,7 +477,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -485,7 +485,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -515,14 +515,14 @@ class ResourceType19(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -531,7 +531,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -574,7 +574,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     email: str
     name: Optional[str] = None
@@ -582,7 +582,7 @@ class ExposureOwner(BaseParserModel):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     field: str
     operator: str
@@ -613,7 +613,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -677,7 +677,7 @@ class CompiledSingularTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -743,7 +743,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -810,7 +810,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -876,7 +876,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -942,7 +942,7 @@ class CompiledSqlNode(BaseParserModel):
 
 class CompiledGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -1009,7 +1009,7 @@ class CompiledGenericTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1076,7 +1076,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1142,7 +1142,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1203,7 +1203,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1265,7 +1265,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1326,7 +1326,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1387,7 +1387,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1448,7 +1448,7 @@ class ParsedSqlNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1488,7 +1488,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1497,7 +1497,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1524,7 +1524,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -1550,7 +1550,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     unique_id: str
@@ -1577,7 +1577,7 @@ class ParsedExposure(BaseParserModel):
 
 class ParsedMetric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     unique_id: str
@@ -1610,7 +1610,7 @@ class ParsedMetric(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     raw_sql: str
     compiled: bool
@@ -1676,7 +1676,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1716,7 +1716,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v7.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v7.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -67,7 +67,7 @@ class Docs(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -87,7 +87,7 @@ class ColumnInfo(BaseParserModel):
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -141,7 +141,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -194,7 +194,7 @@ class ResourceType10(Enum):
 
 class ParsedSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -274,7 +274,7 @@ class ResourceType15(Enum):
 
 class ParsedGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     test_metadata: TestMetadata
     database: Optional[str] = None
@@ -341,7 +341,7 @@ class ResourceType16(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -447,7 +447,7 @@ class ResourceType18(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -457,7 +457,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.3.0b2'
@@ -472,7 +472,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -494,7 +494,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -502,7 +502,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -537,14 +537,14 @@ class SupportedLanguage(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -553,7 +553,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -596,7 +596,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     email: str
     name: Optional[str] = None
@@ -611,7 +611,7 @@ class ExposureConfig(BaseParserModel):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     field: str
     operator: str
@@ -627,7 +627,7 @@ class Period1(Enum):
 
 class MetricTime(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period1] = None
@@ -669,7 +669,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     compiled: bool
     database: Optional[str] = None
@@ -734,7 +734,7 @@ class CompiledSingularTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     compiled: bool
     database: Optional[str] = None
@@ -804,7 +804,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     compiled: bool
     database: Optional[str] = None
@@ -875,7 +875,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     compiled: bool
     database: Optional[str] = None
@@ -945,7 +945,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     compiled: bool
     database: Optional[str] = None
@@ -1015,7 +1015,7 @@ class CompiledSqlNode(BaseParserModel):
 
 class CompiledGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     test_metadata: TestMetadata
     compiled: bool
@@ -1083,7 +1083,7 @@ class CompiledGenericTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     compiled: bool
     database: Optional[str] = None
@@ -1154,7 +1154,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     compiled: bool
     database: Optional[str] = None
@@ -1224,7 +1224,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1289,7 +1289,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1355,7 +1355,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1420,7 +1420,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1485,7 +1485,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1550,7 +1550,7 @@ class ParsedSqlNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1591,7 +1591,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1600,7 +1600,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1627,7 +1627,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     package_name: str
@@ -1654,7 +1654,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     unique_id: str
@@ -1686,7 +1686,7 @@ class ParsedExposure(BaseParserModel):
 
 class ParsedMetric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     unique_id: str
@@ -1724,7 +1724,7 @@ class ParsedMetric(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     compiled: bool
     database: Optional[str] = None
@@ -1794,7 +1794,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1834,7 +1834,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v8.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v8.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -79,7 +79,7 @@ class ColumnInfo(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -87,7 +87,7 @@ class DependsOn(BaseParserModel):
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -141,7 +141,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -218,7 +218,7 @@ class SeedConfig(BaseParserModel):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
 
@@ -229,7 +229,7 @@ class ResourceType9(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -239,7 +239,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.4.1'
@@ -254,7 +254,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -276,7 +276,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -284,7 +284,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -319,7 +319,7 @@ class SupportedLanguage(Enum):
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -332,7 +332,7 @@ class ResourceType11(Enum):
 
 class Documentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType11
@@ -363,7 +363,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     email: str
     name: Optional[str] = None
@@ -382,7 +382,7 @@ class ResourceType13(Enum):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     field: str
     operator: str
@@ -398,7 +398,7 @@ class Period1(Enum):
 
 class MetricTime(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period1] = None
@@ -440,7 +440,7 @@ class NodeConfig(BaseParserModel):
 
 class SingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -504,7 +504,7 @@ class SingularTestNode(BaseParserModel):
 
 class HookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -574,7 +574,7 @@ class HookNode(BaseParserModel):
 
 class ModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -643,7 +643,7 @@ class ModelNode(BaseParserModel):
 
 class RPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -712,7 +712,7 @@ class RPCNode(BaseParserModel):
 
 class SqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -781,7 +781,7 @@ class SqlNode(BaseParserModel):
 
 class GenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     test_metadata: TestMetadata
     database: Optional[str] = None
@@ -848,7 +848,7 @@ class GenericTestNode(BaseParserModel):
 
 class SnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -893,7 +893,7 @@ class SnapshotNode(BaseParserModel):
 
 class SeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -955,7 +955,7 @@ class SeedNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -964,7 +964,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -991,7 +991,7 @@ class ExternalTable(BaseParserModel):
 
 class Macro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType10
@@ -1016,7 +1016,7 @@ class Macro(BaseParserModel):
 
 class Exposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType12
@@ -1048,7 +1048,7 @@ class Exposure(BaseParserModel):
 
 class Metric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType13
@@ -1085,7 +1085,7 @@ class Metric(BaseParserModel):
 
 class AnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1154,7 +1154,7 @@ class AnalysisNode(BaseParserModel):
 
 class SourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1193,7 +1193,7 @@ class SourceDefinition(BaseParserModel):
 
 class ManifestV8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v9.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v9.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -67,7 +67,7 @@ class Docs(BaseParserModel):
 
 class ContractConfig(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
 
@@ -83,7 +83,7 @@ class Type(Enum):
 
 class ColumnLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -94,7 +94,7 @@ class ColumnLevelConstraint(BaseParserModel):
 
 class RefArgs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     package: Optional[str] = None
@@ -103,7 +103,7 @@ class RefArgs(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -111,7 +111,7 @@ class DependsOn(BaseParserModel):
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     id: str
     sql: str
@@ -119,7 +119,7 @@ class InjectedCTE(BaseParserModel):
 
 class Contract(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     enforced: Optional[bool] = False
     checksum: Optional[str] = None
@@ -168,7 +168,7 @@ class Access(Enum):
 
 class ModelLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     type: Type
     name: Optional[str] = None
@@ -192,7 +192,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -277,7 +277,7 @@ class SeedConfig(BaseParserModel):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     macros: Optional[List[str]] = []
 
@@ -288,7 +288,7 @@ class ResourceType9(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -298,7 +298,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.5.0b5'
@@ -313,7 +313,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -335,7 +335,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -343,7 +343,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -378,7 +378,7 @@ class SupportedLanguage(Enum):
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     type: Optional[str] = None
@@ -391,7 +391,7 @@ class ResourceType11(Enum):
 
 class Documentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType11
@@ -441,7 +441,7 @@ class ResourceType13(Enum):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     field: str
     operator: str
@@ -457,7 +457,7 @@ class Period1(Enum):
 
 class MetricTime(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period1] = None
@@ -477,7 +477,7 @@ class ResourceType14(Enum):
 
 class Group(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType14
@@ -534,7 +534,7 @@ class ColumnInfo(BaseParserModel):
 
 class SingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -605,7 +605,7 @@ class SingularTestNode(BaseParserModel):
 
 class HookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -683,7 +683,7 @@ class HookNode(BaseParserModel):
 
 class ModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -764,7 +764,7 @@ class ModelNode(BaseParserModel):
 
 class RPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -841,7 +841,7 @@ class RPCNode(BaseParserModel):
 
 class SqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -918,7 +918,7 @@ class SqlNode(BaseParserModel):
 
 class GenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     test_metadata: TestMetadata
     database: Optional[str] = None
@@ -993,7 +993,7 @@ class GenericTestNode(BaseParserModel):
 
 class SnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1044,7 +1044,7 @@ class SnapshotNode(BaseParserModel):
 
 class SeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1109,7 +1109,7 @@ class SeedNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1118,7 +1118,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1145,7 +1145,7 @@ class ExternalTable(BaseParserModel):
 
 class Macro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType10
@@ -1170,7 +1170,7 @@ class Macro(BaseParserModel):
 
 class Exposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType12
@@ -1202,7 +1202,7 @@ class Exposure(BaseParserModel):
 
 class Metric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     resource_type: ResourceType13
@@ -1242,7 +1242,7 @@ class Metric(BaseParserModel):
 
 class AnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1319,7 +1319,7 @@ class AnalysisNode(BaseParserModel):
 
 class SourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1358,7 +1358,7 @@ class SourceDefinition(BaseParserModel):
 
 class ManifestV9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v1.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v1.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class BaseArtifactMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '0.19.0'
@@ -44,7 +44,7 @@ class Status2(Enum):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -53,7 +53,7 @@ class TimingInfo(BaseParserModel):
 
 class RunResultOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingInfo]
@@ -66,7 +66,7 @@ class RunResultOutput(BaseParserModel):
 
 class RunResultsV1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: BaseArtifactMetadata
     results: List[RunResultOutput]

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v2.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v2.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class BaseArtifactMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '0.20.0rc1'
@@ -44,7 +44,7 @@ class Status2(Enum):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -53,7 +53,7 @@ class TimingInfo(BaseParserModel):
 
 class RunResultOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingInfo]
@@ -67,7 +67,7 @@ class RunResultOutput(BaseParserModel):
 
 class RunResultsV2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: BaseArtifactMetadata
     results: List[RunResultOutput]

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v3.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v3.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class BaseArtifactMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '0.21.0rc1'
@@ -45,7 +45,7 @@ class Status2(Enum):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -54,7 +54,7 @@ class TimingInfo(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v2.json'
     dbt_version: Optional[str] = '0.21.0rc1'
@@ -69,7 +69,7 @@ class Status3(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -91,7 +91,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     period: Period
@@ -99,7 +99,7 @@ class Time(BaseParserModel):
 
 class RunResultOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingInfo]
@@ -113,7 +113,7 @@ class RunResultOutput(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -122,7 +122,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class RunResultsV3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: BaseArtifactMetadata
     results: List[RunResultOutput]
@@ -132,7 +132,7 @@ class RunResultsV3(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v4.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v4.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class BaseArtifactMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '1.0.0b2'
@@ -45,7 +45,7 @@ class Status2(Enum):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -54,7 +54,7 @@ class TimingInfo(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.0.0b2'
@@ -69,7 +69,7 @@ class Status3(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -91,7 +91,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -99,7 +99,7 @@ class Time(BaseParserModel):
 
 class RunResultOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingInfo]
@@ -113,7 +113,7 @@ class RunResultOutput(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -122,7 +122,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class RunResultsV4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: BaseArtifactMetadata
     results: List[RunResultOutput]
@@ -132,7 +132,7 @@ class RunResultsV4(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v5.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v5.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class BaseArtifactMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '1.7.0b1'
@@ -24,7 +24,7 @@ class BaseArtifactMetadata(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[str] = None
@@ -54,7 +54,7 @@ class Status2(Enum):
 
 class RunResultOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingInfo]
@@ -71,7 +71,7 @@ class RunResultOutput(BaseParserModel):
 
 class RunResultsV5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: BaseArtifactMetadata
     results: List[RunResultOutput]

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v6.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v6.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class Metadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '1.8.0a1'
@@ -45,7 +45,7 @@ class Status2(Enum):
 
 class TimingItem(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[str] = None
@@ -54,7 +54,7 @@ class TimingItem(BaseParserModel):
 
 class Result(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingItem]
@@ -71,7 +71,7 @@ class Result(BaseParserModel):
 
 class RunResultsV6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: Metadata = Field(..., title='BaseArtifactMetadata')
     results: List[Result]

--- a/dbt_artifacts_parser/parsers/sources/sources_v1.py
+++ b/dbt_artifacts_parser/parsers/sources/sources_v1.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v1.json'
     dbt_version: Optional[str] = '0.19.0'
@@ -28,7 +28,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -50,7 +50,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     period: Period
@@ -58,7 +58,7 @@ class Time(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -67,7 +67,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -80,7 +80,7 @@ class SourceFreshnessOutput(BaseParserModel):
 
 class SourcesV1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: FreshnessMetadata
     results: List[Union[SourceFreshnessRuntimeError, SourceFreshnessOutput]]

--- a/dbt_artifacts_parser/parsers/sources/sources_v2.py
+++ b/dbt_artifacts_parser/parsers/sources/sources_v2.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v2.json'
     dbt_version: Optional[str] = '0.21.0rc1'
@@ -28,7 +28,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -50,7 +50,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: int
     period: Period
@@ -58,7 +58,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -67,7 +67,7 @@ class TimingInfo(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -76,7 +76,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -92,7 +92,7 @@ class SourceFreshnessOutput(BaseParserModel):
 
 class SourcesV2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: FreshnessMetadata
     results: List[Union[SourceFreshnessRuntimeError, SourceFreshnessOutput]]

--- a/dbt_artifacts_parser/parsers/sources/sources_v3.py
+++ b/dbt_artifacts_parser/parsers/sources/sources_v3.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.0.0b2'
@@ -28,7 +28,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -50,7 +50,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -58,7 +58,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -67,7 +67,7 @@ class TimingInfo(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -76,7 +76,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -92,7 +92,7 @@ class SourceFreshnessOutput(BaseParserModel):
 
 class SourcesV3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="allow",
     )
     metadata: FreshnessMetadata
     results: List[Union[SourceFreshnessRuntimeError, SourceFreshnessOutput]]


### PR DESCRIPTION
This PR updates the default for extra fields from `forbid` to `allow`, because dbt does its own parsing and validation before it generates any artifacts. With the current setting of `forbid` I'm unable to parse my manifest files with this library even though they're valid according to dbt. 

Please let me know if I'm overlooking anything, but it seems like this config is trying to do validation on files that have already been validated, and this is an incorrect failure. 

more discussion in #103 