### PR TITLE
Adding time_spine field for manifest

### DIFF
--- a/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
@@ -789,6 +789,7 @@ class Nodes4(BaseParserModel):
     deprecation_date: Optional[str] = None
     defer_relation: Optional[DeferRelation1] = None
     primary_key: Optional[List[str]] = None
+    time_spine: Optional[str] = None
 
 
 class Config7(BaseParserModel):

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
@@ -740,6 +740,12 @@ class DeferRelation1(BaseParserModel):
     tags: List[str]
     config: Optional[Config6] = None
 
+class TimeSpine(BaseParserModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    standard_granularity_column: str
+
 
 class Nodes4(BaseParserModel):
     model_config = ConfigDict(
@@ -789,7 +795,7 @@ class Nodes4(BaseParserModel):
     deprecation_date: Optional[str] = None
     defer_relation: Optional[DeferRelation1] = None
     primary_key: Optional[List[str]] = None
-    time_spine: Optional[str] = None
+    time_spine: Optional[TimeSpine] = None
 
 
 class Config7(BaseParserModel):


### PR DESCRIPTION
### **User description**
The latest version of `manifest.json` from dbt Cloud contains a `time_spine` field for nodes. This PR adds this field so manifests can be parsed.

Extra info: this is what the `metadata` field looks like from the `manifest.json` I downloaded:
```json
{
    "metadata": {
        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
        "dbt_version": "2024.9.239",
        ...
    },
```


___

### **PR Type**
enhancement


___

### **Description**
- Added a new `time_spine` field to the `Nodes4` class in the `manifest_v12.py` file.
- This field is optional and allows for parsing the `time_spine` attribute from the latest `manifest.json` version.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest_v12.py</strong><dd><code>Add `time_spine` field to `Nodes4` class in manifest parser</code></dd></summary>
<hr>

dbt_artifacts_parser/parsers/manifest/manifest_v12.py

<li>Added <code>time_spine</code> field to <code>Nodes4</code> class.<br> <li> The <code>time_spine</code> field is optional and of type <code>str</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/dbt-artifacts-parser/pull/112/files#diff-b56fba67732fa72f0d8aa3ebe904809d0085f243ba88a9e6a2a4a037cb027eaa">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

