### PR TITLE
Update CatalogV1 data model with latest schema

### DIFF
--- a/dbt_artifacts_parser/__init__.py
+++ b/dbt_artifacts_parser/__init__.py
@@ -18,4 +18,4 @@
 A dbt artifacts parser in python
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/dbt_artifacts_parser/parsers/catalog/catalog_v1.py
+++ b/dbt_artifacts_parser/parsers/catalog/catalog_v1.py
@@ -15,9 +15,10 @@ class Metadata(BaseParserModel):
         extra='forbid',
     )
     dbt_schema_version: Optional[str] = None
-    dbt_version: Optional[str] = '1.9.0b2'
+    dbt_version: Optional[str] = '1.10.0a1'
     generated_at: Optional[str] = None
     invocation_id: Optional[str] = None
+    invocation_started_at: Optional[str] = None
     env: Optional[Dict[str, str]] = None
 
 

--- a/dbt_artifacts_parser/resources/catalog/catalog_v1.json
+++ b/dbt_artifacts_parser/resources/catalog/catalog_v1.json
@@ -12,12 +12,22 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0b2"
+          "default": "1.10.0a1"
         },
         "generated_at": {
           "type": "string"
         },
         "invocation_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "invocation_started_at": {
           "anyOf": [
             {
               "type": "string"


### PR DESCRIPTION
Updates the `CatalogV1` data model to support the latest [schema](https://schemas.getdbt.com/dbt/catalog/v1.json) changes.

### Changes
- Updated default dbt_version from `1.9.0b2` to `1.10.0a1`
- Added optional `invocation_started_at` field to `Metadata` model
- Bumped package version to `0.9.1`
