### PR TITLE
Add `py.typed` PEP 561 marker

### DIFF
--- a/dbt_artifacts_parser/parser.py
+++ b/dbt_artifacts_parser/parser.py
@@ -252,7 +252,7 @@ def parse_run_results(
         return RunResultsV5(**run_results)
     elif dbt_schema_version == ArtifactTypes.RUN_RESULTS_V6.value.dbt_schema_version:
         return RunResultsV6(**run_results)
-    raise ValueError("Not a manifest.json")
+    raise ValueError("Not a run_results.json")
 
 
 def parse_run_results_v1(run_results: dict) -> RunResultsV1:
@@ -322,7 +322,7 @@ def parse_sources(sources: dict) -> Union[SourcesV1, SourcesV2, SourcesV3]:
         return SourcesV2(**sources)
     elif dbt_schema_version == ArtifactTypes.SOURCES_V3.value.dbt_schema_version:
         return SourcesV3(**sources)
-    raise ValueError("Not a manifest.json")
+    raise ValueError("Not a sources.json")
 
 
 def parse_sources_v1(sources: dict) -> SourcesV1:


### PR DESCRIPTION
Hey Yu! I'm Jairus w/ dbt labs and funnily enough, we've crossed paths before on other OSS projects. It's great to see all the awesome work you've contributed over the years!!

For context:

I'm currently working on [dbt-labs/dbt-mcp#745](https://github.com/dbt-labs/dbt-mcp/pull/745) which aims to replace hand-rolled Pydantic schemas with `dbt-artifacts-parser` for artifact parsing. With the suggestion of @b-per , I added `dbt-artifacts-parser` as a dependency to the project.

So as u know, this package already has full return-type annotations on all `parse_*()` functions and Pydantic
typed fields on every versioned model class. This is GREAT; however, the only thing missing was the [PEP 561 marker](https://peps.python.org/pep-0561/) that tells mypy that the package comes w/ its own types. This meant that every import site in dbt-mcp required a `# type: ignore[import-untyped]` comment.

## What this PR does

1. Add `py.typed` (PEP 561 marker)
2. Kinda random but fixes 2 small errors in `ValueError` messages for run_results.json parsing that pointed to manigest.json


## Manual validation of `py.typed`

1. Built the package locally w/ my changes via `uv build`
2. Pointed the dbt-mcp branch to the local editable install:
   ```bash
   uv add ../dbt-artifacts-parser/dist/dbt_artifacts_parser-0.13.1-py3-none-any.whl
   ```
3. Removed all `# type: ignore[import-untyped]` comments from the dbt-mcp import sites:
4. Ran mypy against those files:
   ```bash
   uv run mypy src/dbt_mcp/dbt_admin/run_artifacts/artifacts/
   ```
...and it worked! Hoping to get this merged and released so I can clean-up imports and leverage mypy with your project.