### PR TITLE
chore: add Cursor sandbox policy

### DIFF
--- a/.cursor/sandbox.json
+++ b/.cursor/sandbox.json
@@ -1,0 +1,17 @@
+{
+  "type": "workspace_readwrite",
+  "enableSharedBuildCache": true,
+  "networkPolicy": {
+    "default": "deny",
+    "allow": [
+      "github.com",
+      "api.github.com",
+      "codeload.github.com",
+      "*.githubusercontent.com",
+      "pypi.org",
+      "files.pythonhosted.org",
+      "astral.sh",
+      "*.trunk.io"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add repo-local `.cursor/sandbox.json`
- use workspace read/write sandboxing
- deny outbound network access by default
- allow only GitHub, PyPI/uv, and Trunk endpoints used by the repository
- enable shared build caches

## Validation
- policy follows the current Cursor `sandbox.json` schema
- allowlist reflects the repository's Python/PyPI and Trunk workflows