### PR TITLE
ci: reduce GitHub Actions runner usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,28 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/test.yml
+      - pyproject.toml
+      - uv.lock
+      - dbt_artifacts_parser/**/*.py
+      - dev/integration_tests/**
+      - tests/**/*.py
+      - tests/resources/**
+      - pylintrc
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-slim
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJSON(github.event_name == 'pull_request' && '["3.13"]' || '["3.10","3.11","3.12","3.13"]') }}
       fail-fast: false
 
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/test.yml
+      - noxfile.py
       - pyproject.toml
       - uv.lock
       - dbt_artifacts_parser/**/*.py
@@ -16,6 +17,7 @@ on:
       - main
     paths:
       - .github/workflows/test.yml
+      - noxfile.py
       - pyproject.toml
       - uv.lock
       - dbt_artifacts_parser/**/*.py
@@ -32,31 +34,31 @@ concurrency:
 jobs:
   test:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
-    runs-on: ubuntu-slim
-    strategy:
-      matrix:
-        python-version: ${{ fromJSON(github.event_name == 'pull_request' && '["3.13"]' || '["3.10","3.11","3.12","3.13"]') }}
-      fail-fast: false
-
+    name: Test supported Python versions
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
-
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # ratchet:actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+          enable-cache: true
+      - name: Install supported Python versions
+        run: uv python install 3.10 3.11 3.12 3.13
+      - name: Run tests across Python versions in parallel
         run: |
-          python -m pip install -r requirements.setup.txt
-          bash dev/setup.sh --deps "development"
-      - name: Run tests
-        run: bash dev/test_python.sh
+          set -euo pipefail
+          nox_spec='nox[uv]==2026.7.11'
+          uvx --from "${nox_spec}" nox --list >/dev/null
+          printf '%s\0' 3.10 3.11 3.12 3.13 \
+            | xargs -0 -P "$(nproc)" -I{} \
+                uvx --from "${nox_spec}" nox --session "tests-{}"
+      - name: Prepare primary validation environment
+        run: uv sync --frozen --all-extras --python 3.13
       - name: Test build
-        run: |
-          bash dev/build.sh
+        run: uv run bash dev/build.sh
       - name: Test installation from wheel
         run: |
           set -euo pipefail
@@ -66,7 +68,6 @@ jobs:
             echo "No wheel found under dist/"
             exit 1
           fi
-          python -m pip install --upgrade pip
-          python -m pip install "${wheels[@]}"
-          python -c 'import dbt_artifacts_parser'
-          python dev/integration_tests/verify_parsers.py --verbose
+          uv pip install "${wheels[@]}"
+          uv run python -c 'import dbt_artifacts_parser'
+          uv run python dev/integration_tests/verify_parsers.py --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ concurrency:
 
 jobs:
   test:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Test supported environments
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   test:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
-    name: Test supported Python versions
+    name: Test supported environments
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -45,16 +45,8 @@ jobs:
         uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           enable-cache: true
-      - name: Install supported Python versions
-        run: uv python install 3.10 3.11 3.12 3.13
-      - name: Run tests across Python versions in parallel
-        run: |
-          set -euo pipefail
-          nox_spec='nox[uv]==2026.7.11'
-          uvx --from "${nox_spec}" nox --list >/dev/null
-          printf '%s\0' 3.10 3.11 3.12 3.13 \
-            | xargs -0 -P "$(nproc)" -I{} \
-                uvx --from "${nox_spec}" nox --session "tests-{}"
+      - name: Run compatibility tests
+        run: uv run --with "nox[uv]==2026.7.11" bash dev/test_all.sh
       - name: Prepare primary validation environment
         run: uv sync --frozen --all-extras --python 3.13
       - name: Test build

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,15 @@ run-pre-commit:
 update-pre-commit:
 	uv run pre-commit autoupdate
 
-# Run the unit tests.
+# Run the unit tests in the current environment.
 .PHONY: test
 test:
 	uv run bash ./dev/test_python.sh
+
+# Run the complete supported-Python suite through the same entrypoint as CI.
+.PHONY: test-all
+test-all:
+	uv run --with "nox[uv]==2026.7.11" bash ./dev/test_all.sh
 
 # Build the package
 .PHONY: build

--- a/dev/test_all.sh
+++ b/dev/test_all.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+cd "${REPO_ROOT}"
+
+exec nox --tags ci "$@"

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,24 @@
+"""Nox sessions for supported Python versions."""
+
+from __future__ import annotations
+
+import nox
+
+PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
+
+nox.options.default_venv_backend = "uv"
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def tests(session: nox.Session) -> None:
+    """Run the test suite in an isolated uv-backed environment."""
+    env = {"UV_PROJECT_ENVIRONMENT": str(session.virtualenv.location)}
+    session.run_install(
+        "uv",
+        "sync",
+        "--frozen",
+        "--all-extras",
+        f"--python={session.virtualenv.location}",
+        env=env,
+    )
+    session.run("bash", "dev/test_python.sh", external=True, env=env)

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,12 +13,5 @@ nox.options.default_venv_backend = "uv"
 def tests(session: nox.Session) -> None:
     """Run the test suite in an isolated uv-backed environment."""
     env = {"UV_PROJECT_ENVIRONMENT": str(session.virtualenv.location)}
-    session.run_install(
-        "uv",
-        "sync",
-        "--frozen",
-        "--all-extras",
-        f"--python={session.virtualenv.location}",
-        env=env,
-    )
+    session.run_install("uv", "sync", "--frozen", "--all-extras", env=env)
     session.run("bash", "dev/test_python.sh", external=True, env=env)

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,9 +7,11 @@ import nox
 PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
 
 nox.options.default_venv_backend = "uv"
+nox.options.download_python = "auto"
+nox.options.reuse_venv = "yes"
 
 
-@nox.session(python=PYTHON_VERSIONS)
+@nox.session(python=PYTHON_VERSIONS, tags=["ci"])
 def tests(session: nox.Session) -> None:
     """Run the test suite in an isolated uv-backed environment."""
     env = {"UV_PROJECT_ENVIRONMENT": str(session.virtualenv.location)}

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,5 +13,12 @@ nox.options.default_venv_backend = "uv"
 def tests(session: nox.Session) -> None:
     """Run the test suite in an isolated uv-backed environment."""
     env = {"UV_PROJECT_ENVIRONMENT": str(session.virtualenv.location)}
-    session.run_install("uv", "sync", "--frozen", "--all-extras", env=env)
+    session.run_install(
+        "uv",
+        "sync",
+        "--frozen",
+        "--all-extras",
+        f"--python={session.virtualenv.location}",
+        env=env,
+    )
     session.run("bash", "dev/test_python.sh", external=True, env=env)


### PR DESCRIPTION
## Summary

Preserve the complete supported Python range on pull requests while moving compatibility ownership out of GitHub Actions.

- no Python-version matrix or CI-side subprocess/session-name orchestration
- `noxfile.py` owns supported versions and uv-backed isolated environments
- `dev/test_all.sh` is a tiny tagged-Nox wrapper and `make test-all` is the local entrypoint
- CI invokes the same wrapper through uv
- package build and wheel installation/parser verification run once on the primary environment, avoiding concurrent `dist/` writes
- path gating and superseded-run cancellation remain; when the workflow is triggered, the test job runs for draft and ready-for-review PRs alike

Future supported-version changes are localized to Nox configuration.